### PR TITLE
Transitive dependency issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,56 @@
       <artifactId>clojure</artifactId>
       <version>1.10.1</version>
     </dependency>
+    <dependency>
+      <groupId>keechma</groupId>
+      <artifactId>pipelines</artifactId>
+      <version>0.0.6</version>
+    </dependency>
+    <dependency>
+      <groupId>tick</groupId>
+      <artifactId>tick</artifactId>
+      <version>0.4.30-alpha</version>
+    </dependency>
+    <dependency>
+      <groupId>com.cognitect</groupId>
+      <artifactId>transit-cljs</artifactId>
+      <version>0.8.264</version>
+    </dependency>
+    <dependency>
+      <groupId>metosin</groupId>
+      <artifactId>malli</artifactId>
+      <version>0.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.cognitect</groupId>
+      <artifactId>transit-clj</artifactId>
+      <version>1.0.324</version>
+    </dependency>
+    <dependency>
+      <groupId>funcool</groupId>
+      <artifactId>promesa</artifactId>
+      <version>5.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>keechma</groupId>
+      <artifactId>next</artifactId>
+      <version>0.0.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.clojure</groupId>
+      <artifactId>core.async</artifactId>
+      <version>0.7.559</version>
+    </dependency>
+    <dependency>
+      <groupId>metosin</groupId>
+      <artifactId>sieppari</artifactId>
+      <version>0.0.0-alpha13</version>
+    </dependency>
+    <dependency>
+      <groupId>lambdaisland</groupId>
+      <artifactId>fetch</artifactId>
+      <version>0.0.23</version>
+    </dependency>
   </dependencies>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -38,10 +88,6 @@
     <repository>
       <id>clojars</id>
       <url>https://repo.clojars.org/</url>
-    </repository>
-    <repository>
-      <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
   </repositories>
   <distributionManagement>


### PR DESCRIPTION
## Problem

Since this package is neither on maven or clojar it has to be fetched from git directly. Since I only use Lein, fetching directly from git is not supported out of the box, so I'm using this plugin https://github.com/reifyhealth/lein-git-down to fetch git dependencies. This plugin supports transitive dependency (as can be seen here https://github.com/reifyhealth/lein-git-down#transitive-dependencies) but it seems like if it loads pom.xml without dependencies defined, it will not look for dependencies in deps.edn.

That wouldn't be a problem in it self but I also use `nl.mediquest/duct.module.reitit "1.0.3"` package which for this particular verions uses `metosin/malli "0.2.1"`. And since the transitive dependency is not working, funicular uses version `0.2.1` which is problem as minimum verions for this package to work is `0.3.0`

## Solution

Update `pom.xml` to match `deps.edn` with simple `clojure -Spom`

## How to reproduce

Create Lein project and add following into `project.clj`

```
:dependencies [
   ...
   [com.verybigthings/funicular "6e8226ff1469436e89743a5281c25033d9076fb8"]
   ...
]
:plugins[
   ...
   [reifyhealth/lein-git-down "0.4.1"]
   ...
]
:git-down {
   ...
   com.verybigthings/funicular {:coordinates verybigthings/funicular}
   ...
}
```
Then add funicular and create simple route that has `input-schema :any` and it will throw error

```
Execution error (ExceptionInfo) at malli.core/-fail! (core.cljc:79).
:malli.core/invalid-schema {:schema :any}
```

## How to test

Just point funicular to use this commit and the error will disappear.
 
```
:dependencies [
   ...
   [com.verybigthings/funicular "17cb7f240f5cad88596f539a399fb074e3f9d9ff"]
   ...
]
```