### PR TITLE
Fix typo(s)

### DIFF
--- a/doc/execute-example.clj
+++ b/doc/execute-example.clj
@@ -1,9 +1,11 @@
 (ns app.funicular-example
   (:require [com.verybigthings.funicular.core :as fun]
-            [clojure.edn :as edn]))
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [app.shared.schema :refer [registry]]))
 
 (let [raw-edn (edn/read-string (slurp (io/resource "funicular.edn")))
-      compiled (fun/compile api)]
+      compiled (fun/compile raw-edn {:malli/registry registry})]
   (fun/execute compiled
                {}
                {:command [:api-v1.tracking/log-site-visitor

--- a/doc/execute_example.clj
+++ b/doc/execute_example.clj
@@ -1,4 +1,4 @@
-(ns app.funicular-example
+(ns execute-example
   (:require [com.verybigthings.funicular.core :as fun]
             [clojure.edn :as edn]
             [clojure.java.io :as io]


### PR DESCRIPTION
Fix typos in documentation text and update the example (from the same documentation) to make it work.